### PR TITLE
Fix mixed content block

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 	<!-- Schema.org markup for Google+ -->
 	<meta itemprop="name" content="Simulating The World (In Emoji)">
 	<meta itemprop="description" content="An interactive guide to thinking in systems">
-	<meta itemprop="image" content="http://ncase.me/simulating/social/thumbnail.png">
+	<meta itemprop="image" content="https://ncase.me/simulating/social/thumbnail.png">
 
 	<!-- Twitter Card data -->
 	<meta name="twitter:card" content="summary_large_image">
@@ -19,13 +19,13 @@
 	<meta name="twitter:title" content="Simulating The World (In Emoji)">
 	<meta name="twitter:description" content="An interactive guide to thinking in systems">
 	<meta name="twitter:creator" content="@ncasenmare">
-	<meta name="twitter:image" content="http://ncase.me/simulating/social/thumbnail.png">
+	<meta name="twitter:image" content="https://ncase.me/simulating/social/thumbnail.png">
 
 	<!-- Open Graph data -->
 	<meta property="og:title" content="Simulating The World (In Emoji)">
 	<meta property="og:type" content="website">
-	<meta property="og:url" content="http://ncase.me/simulating/">
-	<meta property="og:image" content="http://ncase.me/simulating/social/thumbnail.png">
+	<meta property="og:url" content="https://ncase.me/simulating/">
+	<meta property="og:image" content="https://ncase.me/simulating/social/thumbnail.png">
 	<meta property="og:description" content="An interactive guide to thinking in systems">
 
 	<!-- Styles -->
@@ -588,13 +588,13 @@
 	<div id="social">
 		<!-- Buttons generated with https://simplesharingbuttons.com/ -->
 		<ul class="share-buttons">
-			<li><a href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fncase.me%2Fsimulating%2F&t=Simulating%20The%20World%20(In%20Emoji%F0%9F%98%98)" title="Share on Facebook" target="_blank"><img src="styles/social/Facebook.svg"></a></li>
-			<li><a href="https://twitter.com/intent/tweet?source=http%3A%2F%2Fncase.me%2Fsimulating%2F&text=Simulating%20The%20World%20(In%20Emoji%F0%9F%98%98):%20http%3A%2F%2Fncase.me%2Fsimulating%2F&via=ncasenmare" target="_blank" title="Tweet"><img src="styles/social/Twitter.svg"></a></li>
-			<li><a href="http://www.tumblr.com/share?v=3&u=http%3A%2F%2Fncase.me%2Fsimulating%2F&t=Simulating%20The%20World%20(In%20Emoji%F0%9F%98%98)&s=" target="_blank" title="Post to Tumblr"><img src="styles/social/Tumblr.svg"></a></li>
-			<li><a href="http://pinterest.com/pin/create/button/?url=http%3A%2F%2Fncase.me%2Fsimulating%2F&media=http://ncase.me/simulating/social/thumbnail.png&description=An%20interactive%20guide%20to%20thinking%20in%20systems" target="_blank" title="Pin it"><img src="styles/social/Pinterest.svg"></a></li>
-			<li><a href="http://www.reddit.com/submit?url=http%3A%2F%2Fncase.me%2Fsimulating%2F&title=Simulating%20The%20World%20(In%20Emoji%F0%9F%98%98)" target="_blank" title="Submit to Reddit"><img src="styles/social/Reddit.svg"></a></li>
-			<li><a href="https://pinboard.in/popup_login/?url=http%3A%2F%2Fncase.me%2Fsimulating%2F&title=Simulating%20The%20World%20(In%20Emoji%F0%9F%98%98)&description=An%20interactive%20guide%20to%20thinking%20in%20systems" target="_blank" title="Save to Pinboard"><img src="styles/social/Pinboard.svg"></a></li>
-			<li><a href="mailto:?subject=Simulating%20The%20World%20(In%20Emoji%F0%9F%98%98)&body=An%20interactive%20guide%20to%20thinking%20in%20systems:%20http%3A%2F%2Fncase.me%2Fsimulating%2F" target="_blank" title="Email"><img src="styles/social/Email.svg"></a></li>
+			<li><a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fncase.me%2Fsimulating%2F&t=Simulating%20The%20World%20(In%20Emoji%F0%9F%98%98)" title="Share on Facebook" target="_blank"><img src="styles/social/Facebook.svg"></a></li>
+			<li><a href="https://twitter.com/intent/tweet?source=https%3A%2F%2Fncase.me%2Fsimulating%2F&text=Simulating%20The%20World%20(In%20Emoji%F0%9F%98%98):%20https%3A%2F%2Fncase.me%2Fsimulating%2F&via=ncasenmare" target="_blank" title="Tweet"><img src="styles/social/Twitter.svg"></a></li>
+			<li><a href="https://www.tumblr.com/share?v=3&u=https%3A%2F%2Fncase.me%2Fsimulating%2F&t=Simulating%20The%20World%20(In%20Emoji%F0%9F%98%98)&s=" target="_blank" title="Post to Tumblr"><img src="styles/social/Tumblr.svg"></a></li>
+			<li><a href="https://pinterest.com/pin/create/button/?url=https%3A%2F%2Fncase.me%2Fsimulating%2F&media=https://ncase.me/simulating/social/thumbnail.png&description=An%20interactive%20guide%20to%20thinking%20in%20systems" target="_blank" title="Pin it"><img src="styles/social/Pinterest.svg"></a></li>
+			<li><a href="https://www.reddit.com/submit?url=https%3A%2F%2Fncase.me%2Fsimulating%2F&title=Simulating%20The%20World%20(In%20Emoji%F0%9F%98%98)" target="_blank" title="Submit to Reddit"><img src="styles/social/Reddit.svg"></a></li>
+			<li><a href="https://pinboard.in/popup_login/?url=https%3A%2F%2Fncase.me%2Fsimulating%2F&title=Simulating%20The%20World%20(In%20Emoji%F0%9F%98%98)&description=An%20interactive%20guide%20to%20thinking%20in%20systems" target="_blank" title="Save to Pinboard"><img src="styles/social/Pinboard.svg"></a></li>
+			<li><a href="mailto:?subject=Simulating%20The%20World%20(In%20Emoji%F0%9F%98%98)&body=An%20interactive%20guide%20to%20thinking%20in%20systems:%20https%3A%2F%2Fncase.me%2Fsimulating%2F" target="_blank" title="Email"><img src="styles/social/Email.svg"></a></li>
 		</ul>
 	</div>
 
@@ -638,7 +638,7 @@
 				</p>
 
 				<p class="further_book">
-				<a href="http://www.amazon.com/Thinking-Systems-Donella-H-Meadows/dp/1603580557" target="_blank">
+				<a href="https://www.amazon.com/Thinking-Systems-Donella-H-Meadows/dp/1603580557" target="_blank">
 					<img src="styles/books/thinking.png"/>
 					Thinking In Systems</a>
 				<b>(Donella Meadows, 2008)</b>
@@ -651,7 +651,7 @@
 				</p>
 
 				<p class="further_book">
-				<a href="http://press.princeton.edu/titles/8429.html" target="_blank">
+				<a href="https://press.princeton.edu/titles/8429.html" target="_blank">
 					<img src="styles/books/cas.png"/>
 					Complex Adaptive Systems</a>
 				<b>(Miller &amp; Page, 2007)</b>
@@ -675,7 +675,7 @@
 				</p>
 
 				<p class="further_book">
-				<a href="http://www.fivepercentbook.com/" target="_blank">
+				<a href="https://www.fivepercentbook.com/" target="_blank">
 					<img src="styles/books/five.png"/>
 					The Five Percent</a>
 				<b>(Peter Coleman, 2011)</b>
@@ -734,8 +734,8 @@
 				<p>
 				Also, if you wanna check out my other shtuff,
 				my wobsite is
-				<a href="http://ncase.me" target="_blank">ncase.me</a>.
-				(Might I recommend <a href="http://ncase.me/polygons" target="_blank">Parable of the Polygons</a>?
+				<a href="https://ncase.me" target="_blank">ncase.me</a>.
+				(Might I recommend <a href="https://ncase.me/polygons" target="_blank">Parable of the Polygons</a>?
 				It’s a social-system simulation I made a year ago,
 				in collaboration with Vi Hart,
 				about discrimination &amp; diversity!)


### PR DESCRIPTION
Because the [page is available via https](https://ncase.me/simulating/), the embeds of http resources failed. Change all http links to https, except worrydream and auntiepixelante which are inaccessible via https.

I clicked on all links at the bottom of the page and discovered those mentioned above to be inaccessible if changed to https. Please double check for whether I have missed any upgradeable links.